### PR TITLE
chore(controller): upgrade requirements pyOpenSSL==23.0.0

### DIFF
--- a/rootfs/requirements.txt
+++ b/rootfs/requirements.txt
@@ -17,7 +17,7 @@ morph==0.1.5
 packaging==21.3
 pyasn1==0.4.8
 psycopg2-binary==2.9.3
-pyOpenSSL==22.0.0
+pyOpenSSL==23.0.0
 ndg-httpsclient==0.5.1
 pytz==2022.2.1
 requests==2.28.1


### PR DESCRIPTION
If your change requires any additions or changes to the [documentation][docs] or to the [end-to-end test suite][e2e], please submit them as 1 or more pull requests against that repo and refer to them here.

requires drycc/workflow#1234
requires drycc/workflow-e2e#5678


[docs]: https://github.com/drycc/workflow
[e2e]: https://github.com/drycc/workflow-e2e
